### PR TITLE
Removed closing php tags

### DIFF
--- a/cli/cli.php
+++ b/cli/cli.php
@@ -224,5 +224,3 @@ Class CSSCompression_Cli
 
 // Auto-initialize the cli script
 new CSSCompression_Cli( $_SERVER['argv'] );
-
-?>

--- a/src/CSSCompression.php
+++ b/src/CSSCompression.php
@@ -461,5 +461,3 @@ Class CSSCompression
 		return $this->Control->access( $class, $method, $args );
 	}
 };
-
-?>

--- a/src/lib/Cleanup.php
+++ b/src/lib/Cleanup.php
@@ -217,5 +217,3 @@ Class CSSCompression_Cleanup
 		}
 	}
 };
-
-?>

--- a/src/lib/Color.php
+++ b/src/lib/Color.php
@@ -195,5 +195,3 @@ Class CSSCompression_Color
 		}
 	}
 };
-
-?>

--- a/src/lib/Combine.php
+++ b/src/lib/Combine.php
@@ -187,5 +187,3 @@ Class CSSCompression_Combine
 		}
 	}
 };
-
-?>

--- a/src/lib/Combine/Aural.php
+++ b/src/lib/Combine/Aural.php
@@ -105,5 +105,3 @@ Class CSSCompression_Combine_Aural
 		}
 	}
 };
-
-?>

--- a/src/lib/Combine/Background.php
+++ b/src/lib/Combine/Background.php
@@ -103,5 +103,3 @@ Class CSSCompression_Combine_Background
 		}
 	}
 };
-
-?>

--- a/src/lib/Combine/Border.php
+++ b/src/lib/Combine/Border.php
@@ -94,5 +94,3 @@ Class CSSCompression_Combine_Border
 		}
 	}
 };
-
-?>

--- a/src/lib/Combine/BorderOutline.php
+++ b/src/lib/Combine/BorderOutline.php
@@ -105,5 +105,3 @@ Class CSSCompression_Combine_BorderOutline
 		}
 	}
 };
-
-?>

--- a/src/lib/Combine/BorderRadius.php
+++ b/src/lib/Combine/BorderRadius.php
@@ -259,5 +259,3 @@ Class CSSCompression_Combine_BorderRadius
 		}
 	}
 };
-
-?>

--- a/src/lib/Combine/Font.php
+++ b/src/lib/Combine/Font.php
@@ -121,5 +121,3 @@ Class CSSCompression_Combine_Font
 		}
 	}
 };
-
-?>

--- a/src/lib/Combine/List.php
+++ b/src/lib/Combine/List.php
@@ -100,5 +100,3 @@ Class CSSCompression_Combine_List
 		}
 	}
 };
-
-?>

--- a/src/lib/Combine/MarginPadding.php
+++ b/src/lib/Combine/MarginPadding.php
@@ -186,5 +186,3 @@ Class CSSCompression_Combine_MarginPadding
 		}
 	}
 };
-
-?>

--- a/src/lib/Compress.php
+++ b/src/lib/Compress.php
@@ -208,5 +208,3 @@ Class CSSCompression_Compress
 		}
 	}
 };
-
-?>

--- a/src/lib/Control.php
+++ b/src/lib/Control.php
@@ -232,5 +232,3 @@ Class CSSCompression_Control
 		}
 	}
 };
-
-?>

--- a/src/lib/Exception.php
+++ b/src/lib/Exception.php
@@ -28,5 +28,3 @@ Class CSSCompression_Exception extends Exception
 		return "CSSCompression Exception: [" . $this->code . "] " . $this->message . "\n";
 	}
 };
-
-?>

--- a/src/lib/Format.php
+++ b/src/lib/Format.php
@@ -183,5 +183,3 @@ Class CSSCompression_Format
 		}
 	}
 };
-
-?>

--- a/src/lib/Individuals.php
+++ b/src/lib/Individuals.php
@@ -303,5 +303,3 @@ Class CSSCompression_Individuals
 		}
 	}
 };
-
-?>

--- a/src/lib/Numeric.php
+++ b/src/lib/Numeric.php
@@ -99,5 +99,3 @@ Class CSSCompression_Numeric
 		}
 	}
 };
-
-?>

--- a/src/lib/Option.php
+++ b/src/lib/Option.php
@@ -129,5 +129,3 @@ Class CSSCompression_Option
 		}
 	}
 };
-
-?>

--- a/src/lib/Organize.php
+++ b/src/lib/Organize.php
@@ -145,5 +145,3 @@ Class CSSCompression_Organize
 		}
 	}
 };
-
-?>

--- a/src/lib/Selectors.php
+++ b/src/lib/Selectors.php
@@ -241,5 +241,3 @@ Class CSSCompression_Selectors
 		}
 	}
 };
-
-?>

--- a/src/lib/Setup.php
+++ b/src/lib/Setup.php
@@ -288,5 +288,3 @@ Class CSSCompression_Setup
 		}
 	}
 };
-
-?>

--- a/src/lib/Trim.php
+++ b/src/lib/Trim.php
@@ -209,5 +209,3 @@ Class CSSCompression_Trim
 		}
 	}
 };
-
-?>

--- a/unit/benchmark/benchmark.php
+++ b/unit/benchmark/benchmark.php
@@ -397,5 +397,3 @@ Class CompressionBenchmark
 
 // Autostart the benchmarks
 new CompressionBenchmark;
-
-?>

--- a/unit/file.php
+++ b/unit/file.php
@@ -22,5 +22,3 @@ new FileTest(array(
 	'options' => array(
 	),
 ));
-
-?>

--- a/unit/focus.php
+++ b/unit/focus.php
@@ -30,5 +30,3 @@ new FocusedTest(array(
 	),
 	'expect' => "border-radius:4px;-webkit-border-radius:4px;-moz-border-radius:4px;",
 ));
-
-?>

--- a/unit/src/Color.php
+++ b/unit/src/Color.php
@@ -65,5 +65,3 @@ Class Color
 		return self::wrap( 'blue', true, $msg );
 	}
 };
-
-?>

--- a/unit/src/Core.php
+++ b/unit/src/Core.php
@@ -138,5 +138,3 @@ Class CSScompression_Unit_Core extends CSScompression_Unit_Sheets
 		exit( $exit );
 	}
 };
-
-?>

--- a/unit/src/File.php
+++ b/unit/src/File.php
@@ -141,5 +141,3 @@ Class FileTest
 		}
 	}
 };
-
-?>

--- a/unit/src/Focus.php
+++ b/unit/src/Focus.php
@@ -110,5 +110,3 @@ Class FocusedTest
 		}
 	}
 };
-
-?>

--- a/unit/src/Sandbox.php
+++ b/unit/src/Sandbox.php
@@ -212,5 +212,3 @@ Class CSScompression_Unit_Sandbox
 		}
 	}
 };
-
-?>

--- a/unit/src/Sheets.php
+++ b/unit/src/Sheets.php
@@ -202,5 +202,3 @@ Class CSScompression_Unit_Sheets extends CSScompression_Unit_Sandbox
 		}
 	}
 };
-
-?>

--- a/unit/start.php
+++ b/unit/start.php
@@ -74,5 +74,3 @@ $specials = array(
  * @param (array) specials: Special handling for certain sheets
  */
 new CSScompression_Unit_Core( $block, $specials );
-
-?>


### PR DESCRIPTION
#7: Remove closing php tags ?> from files

"Can easily cause extra white space to be outputted if left in."

This requires testing, which I have not done.
